### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # App Store Connect MCP Server
+[![smithery badge](https://smithery.ai/badge/appstore-connect-mcp-server)](https://smithery.ai/server/appstore-connect-mcp-server)
 
 A Model Context Protocol (MCP) server for interacting with the App Store Connect API. This server provides tools for managing apps, beta testers, bundle IDs, devices, and capabilities in App Store Connect.
 
@@ -33,6 +34,15 @@ A Model Context Protocol (MCP) server for interacting with the App Store Connect
 
 ## Installation
 
+### Installing via Smithery
+
+To install App Store Connect Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/appstore-connect-mcp-server):
+
+```bash
+npx -y @smithery/cli install appstore-connect-mcp-server --client claude
+```
+
+### Manual Installation
 ```bash
 npm install @your-org/app-store-connect-mcp-server
 ```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install App Store Connect Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/appstore-connect-mcp-server

Let me know if any tweaks have to be made!